### PR TITLE
remove shutdown route

### DIFF
--- a/testing/discovery_config.py
+++ b/testing/discovery_config.py
@@ -5,26 +5,25 @@ DISCOVERY_PORT = "1234"
 DISCOVERY_HOST = "localhost"
 TAG = os.environ.get("TAG", "latest")
 
-TIMEOUT = 20
-RETRIES = 15
+TIMEOUT = int(os.environ.get('DISCOVERY_TIMEOUT', '20'))
+RETRIES = int(os.environ.get('DISCOVERY_RETRIES', '15'))
 
 DISABLE_INTENTS_WHITELIST = False
 
 CONTAINER_NAME = "discovery-dev"
-DISCOVERY_SHUTDOWN_SECRET = "greenkeytech"
 DISCOVERY_IMAGE_NAME = "docker.greenkeytech.com/discovery:{}".format(TAG)
 
 DISCOVERY_CONFIG = {
     "LICENSE_KEY": os.environ.get('LICENSE_KEY', ''),
     "NUMBER_OF_INTENTS": "1",
     "MAX_NUMBER_OF_ENTITIES": "100",
-    
+
     # options for increasing log verbosity: payload, debug, verbose
     "CONSOLE_LOG_LEVEL": "verbose",
-    
+
     # if True, pretrained model should be in /scribe/discovery/models
     "USE_SAVED_MODELS": "False",
-    
+
     # Port that Discovery will bind to on the Docker daemon, change if port is taken already
     "PORT": DISCOVERY_PORT,
 }

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -175,4 +175,4 @@ def shutdown_discovery(shutdown=True):
         subprocess.call("docker rm -f {}".format(CONTAINER_NAME), shell=True)
     except Exception as exc:
         LOGGER.exception(exc)
-    time.sleep(3)
+

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 
 import logging
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
-import requests
-import time
 import json
+import requests
+import subprocess
 import sys
+import time
 
 from os.path import abspath, exists, join as join_path
 
 from testing.discovery_config import (
     CONTAINER_NAME,
+    DISCOVERY_CONFIG,
     DISCOVERY_HOST,
     DISCOVERY_PORT,
-    DISCOVERY_SHUTDOWN_SECRET,
-    DISCOVERY_CONFIG,
     RETRIES,
     TIMEOUT,
 )
@@ -54,7 +54,7 @@ def try_discovery(attempt_number):
         return True
     except Exception:
         if attempt_number >= 3:
-            logger.error(
+            LOGGER.error(
                 "Could not reach discovery, attempt {0} of {1}".format(
                     attempt_number + 1, RETRIES
                 )
@@ -78,7 +78,7 @@ def wait_for_discovery_launch():
     """
     # Timeout of 25 seconds for launch
     if not wait_for_discovery_status():
-        logger.error("Couldn't launch Discovery, printing Docker logs:\n---\n")
+        LOGGER.error("Couldn't launch Discovery, printing Docker logs:\n---\n")
         docker_log_and_stop()
         sys.exit(1)
     else:
@@ -90,7 +90,7 @@ def make_sure_directories_exist(directories):
         try:
             assert exists(d)
         except AssertionError:
-            logger.exception(
+            LOGGER.exception(
                 "Error: Check path to directory: {}".format(d), exc_info=True
             )
             print("Terminating program")
@@ -140,7 +140,7 @@ def submit_transcript(
     }
     response = requests.post(DISCOVERY_URL, json=payload)
     if not response.status_code == 200:
-        logger.error(
+        LOGGER.error(
             "Request was not successful. Response Status Code: {}".format(
                 response.status_code
             )
@@ -170,14 +170,9 @@ def shutdown_discovery(shutdown=True):
     if not shutdown:
         return
 
-    logger.info("Shutting down Discovery")
+    LOGGER.info("Shutting down Discovery")
     try:
-        requests.get(
-            "http://{}:{}/shutdown?secret_key={}".format(
-                DISCOVERY_HOST, DISCOVERY_PORT, DISCOVERY_SHUTDOWN_SECRET
-            )
-        )
-    # Windows throws a ConnectionError for a request to shutdown a server which makes it looks like the test fail
-    except requests.exceptions.ConnectionError:
-        pass
+        subprocess.call("docker rm -f {}".format(CONTAINER_NAME), shell=True)
+    except Exception as exc:
+        LOGGER.exception(exc)
     time.sleep(3)


### PR DESCRIPTION
This `shutdown` feature has been discussed for deprecation in discovery. Removing it from the SDK prepares developers for its potential deprecation and allows us to use docker and kubernetes to manage service shutdowns rather than routes within our services.