### PR TITLE
Ashley/add use docker volume env var

### DIFF
--- a/launch_discovery.py
+++ b/launch_discovery.py
@@ -16,7 +16,11 @@ from multiprocessing import Process
 from os.path import abspath, exists, isdir as is_dir, join as join_path
 
 from testing.discovery_config import (
-    CONTAINER_NAME, DISCOVERY_CONFIG, DISCOVERY_PORT, DISCOVERY_IMAGE_NAME, USE_DOCKER_VOLUME
+    CONTAINER_NAME,
+    DISCOVERY_CONFIG,
+    DISCOVERY_IMAGE_NAME,
+    DISCOVERY_PORT,
+    USE_DOCKER_VOLUME,
 )
 
 

--- a/launch_discovery.py
+++ b/launch_discovery.py
@@ -16,7 +16,7 @@ from multiprocessing import Process
 from os.path import abspath, exists, isdir as is_dir, join as join_path
 
 from testing.discovery_config import (
-    CONTAINER_NAME, DISCOVERY_CONFIG, DISCOVERY_PORT, DISCOVERY_IMAGE_NAME
+    CONTAINER_NAME, DISCOVERY_CONFIG, DISCOVERY_PORT, DISCOVERY_IMAGE_NAME, USE_DOCKER_VOLUME
 )
 
 
@@ -98,7 +98,7 @@ def _launch_container(
     # model_dir = ["-v", model_dir] if exists(model_dir) and is_dir(model_dir) else []
 
     # load data into docker volume (supports remote docker executor)
-    if os.environ.get("IN_A_CONTAINER", "True") != "False":
+    if USE_DOCKER_VOLUME:
         volume = load_data_into_docker_volume(custom_directory)
         print("Stored configuration in docker volume {}".format(volume))
     else:

--- a/testing/discovery_config.py
+++ b/testing/discovery_config.py
@@ -13,6 +13,8 @@ DISABLE_INTENTS_WHITELIST = False
 CONTAINER_NAME = "discovery-dev"
 DISCOVERY_IMAGE_NAME = "docker.greenkeytech.com/discovery:{}".format(TAG)
 
+USE_DOCKER_VOLUME = os.environ.get("USE_DOCKER_VOLUME", "True").capitalize() == "True"
+
 DISCOVERY_CONFIG = {
     "LICENSE_KEY": os.environ.get('LICENSE_KEY', ''),
     "NUMBER_OF_INTENTS": "1",
@@ -21,8 +23,8 @@ DISCOVERY_CONFIG = {
     # options for increasing log verbosity: payload, debug, verbose
     "CONSOLE_LOG_LEVEL": "verbose",
 
-    # if True, pretrained model should be in /scribe/discovery/models
-    "USE_SAVED_MODELS": "False",
+    # if False, Discovery will not do any custom model training on startup
+    "TRAIN_MODELS": os.environ.get("TRAIN_MODELS", "True"),
 
     # Port that Discovery will bind to on the Docker daemon, change if port is taken already
     "PORT": DISCOVERY_PORT,


### PR DESCRIPTION
- Create specific configuration variable for controlling whether to use a Docker volume for custom definitions
- Use new `TRAIN_MODELS` variable to turn training on or off
- Alphabetize imports