### PR TITLE
Add CLI SDK

### DIFF
--- a/cli_sdk.py
+++ b/cli_sdk.py
@@ -56,21 +56,21 @@ def log():
 def get_schema(intent, schema_key, transcript):
     payload = submit_transcript(transcript, intent_whitelist=[intent])
     if schema_key in payload:
-        print(json.dumps(payload[schema_key], sort_keys=True, indent=2))
+        return json.dumps(payload[schema_key], sort_keys=True, indent=2)
     else:
-        print("Schema key {} not found".format(schema_key))
+        return "Schema key {} not found".format(schema_key)
 
 
 def get_response(intent, transcript):
     payload = submit_transcript(transcript, intent_whitelist=[intent])
-    print(json.dumps(payload, sort_keys=True, indent=2))
+    return json.dumps(payload, sort_keys=True, indent=2)
 
 
 def get_entities(intent, transcript):
     payload = submit_transcript(transcript, intent_whitelist=[intent])
     entities = get_entities_from_discovery(payload)
     config = {"entities": [entity["label"] for entity in entities]}
-    print(format_entities(entities, config))
+    return format_entities(entities, config)
 
 
 def get_tokens(intent, transcript):
@@ -87,4 +87,4 @@ def get_tokens(intent, transcript):
             output.append(line)
         if separators == 2:
             break
-    print("\n".join(reversed(output)))
+    return "\n".join(reversed(output))

--- a/cli_sdk.py
+++ b/cli_sdk.py
@@ -81,8 +81,7 @@ def get_tokens(intent, transcript):
     output = []
     separators = 0
     for line in reversed(logs):
-        if line.startswith("==="):
-            separators += 1
+        separators += line.startswith("===")
         if separators > 0:
             output.append(line)
         if separators == 2:

--- a/cli_sdk.py
+++ b/cli_sdk.py
@@ -1,0 +1,90 @@
+import json
+import os
+import subprocess
+
+os.environ['USE_DOCKER_VOLUME'] = "False"
+os.environ['TRAIN_MODELS'] = "False"
+
+from testing.discovery_interface import (
+    log_discovery,
+    reload_discovery_config,
+    setup_discovery,
+    submit_transcript,
+    shutdown_discovery,
+    validate_custom_directory,
+    wait_for_discovery_status,
+)
+
+from testing.discovery_config import (CONTAINER_NAME)
+
+from interactive_sdk import (
+    format_entities,
+    get_entities_from_discovery,
+)
+
+INTERPRETER_DIRECTORY = os.environ.get('INTERPRETER_DIRECTORY', 'examples/calling_room')
+DISCOVERY_DOMAINS = [
+    subprocess.check_output(
+        """
+    find {} -follow -name "*.yaml" | while read line; do grep "domain:" $line; done \
+    | awk '{{print $NF}}' | sed -e 's/^\"//' -e 's/\"$//' | uniq | tr '\n' ','
+    """.format(INTERPRETER_DIRECTORY),
+        shell=True).decode('utf-8').strip(",").split(",")
+]
+
+
+def start():
+    setup_discovery(
+        INTERPRETER_DIRECTORY,
+        validate_custom_directory(INTERPRETER_DIRECTORY),
+        DISCOVERY_DOMAINS,
+    )
+
+
+def stop():
+    shutdown_discovery()
+
+
+def reload():
+    reload_discovery_config()
+
+
+def log():
+    log_discovery()
+
+
+def get_schema(intent, schema_key, transcript):
+    payload = submit_transcript(transcript, intent_whitelist=[intent])
+    if schema_key in payload:
+        print(json.dumps(payload[schema_key], sort_keys=True, indent=2))
+    else:
+        print("Schema key {} not found".format(schema_key))
+
+
+def get_response(intent, transcript):
+    payload = submit_transcript(transcript, intent_whitelist=[intent])
+    print(json.dumps(payload, sort_keys=True, indent=2))
+
+
+def get_entities(intent, transcript):
+    payload = submit_transcript(transcript, intent_whitelist=[intent])
+    entities = get_entities_from_discovery(payload)
+    config = {"entities": [entity["label"] for entity in entities]}
+    print(format_entities(entities, config))
+
+
+def get_tokens(intent, transcript):
+    payload = submit_transcript(transcript, intent_whitelist=[intent])
+    logs = subprocess.check_output(
+        "docker logs {}".format(CONTAINER_NAME), stderr=subprocess.STDOUT,
+        shell=True).decode('utf-8').split("\n")
+    output = []
+    separators = 0
+    for line in reversed(logs):
+        if line.startswith("==="):
+            separators += 1
+        if separators > 0:
+            output.append(line)
+        if separators == 2:
+            break
+    print("\n".join(reversed(output)))

--- a/cli_sdk.py
+++ b/cli_sdk.py
@@ -15,7 +15,7 @@ from testing.discovery_interface import (
     wait_for_discovery_status,
 )
 
-from testing.discovery_config import (CONTAINER_NAME)
+from testing.discovery_config import CONTAINER_NAME
 
 from interactive_sdk import (
     format_entities,


### PR DESCRIPTION
Streamlit is slow. It looks nice, but it's painfully slow sometimes to work with.

This PR adds a "CLI SDK" that uses the python command line and offers simple shortcuts to test discovery interpreters:

```bash
$ INTERPRETER_DIRECTORY=examples/calling_room python
Python 3.7.0
>>> from cli_sdk import *

>>> start()
Limiting domains to calling_room
Launching Discovery from Container: docker run --rm -d --name discovery-dev -v [REDACTED]:/custom -p 1234:1234 -e GKT_USERNAME=[REDACTED] -e GKT_SECRETKEY=[REDACTED] -e GKT_API=https://scribeapi.greenkeytech.com/ -e NUMBER_OF_INTENTS=1 -e MAX_NUMBER_OF_ENTITIES=100 -e LOG_LEVEL=debug -e TRAIN_MODELS=False -e PORT=1234 -e USE_BUILT_IN_QUOTES=False -e DISCOVERY_DOMAINS=calling_room docker.greenkeytech.com/discovery:[REDACTED]

6edc608b87296e0f4f757cbe7659f43cb0f94280e720766c5225aacc2e5c2187
Discovery Launched!

>>> get_response('calling_room', "i'm in eleven f")
{
  "calling_room": {
    "room_number": "11 F"
  },
  "identified_quotes": [],
  "identified_trades": [],
  "intents": [
    {
      "entities": [
        {
          "label": "room_number",
          "matches": [
            {
              "endTimeSec": 0.0,
              "interpreted_transcript": "eleven f",
              "lattice_path": [
                [
                  2,
                  0,
                  null
                ],
                [
                  3,
                  0,
                  null
                ]
              ],
              "probability": 1.0,
              "startTimeSec": 0.0,
              "value": "11 F"
            }
          ]
        }
      ],
      "label": "calling_room",
      "probability": 1.0
    }
  ],
  "transcript": "i'm in eleven f"
}

>>> get_schema('calling_room', 'calling_room', "i'm in eleven f")
{
  "room_number": "11 F"
}

>>> get_entities('calling_room', "i'm in eleven f")
        entity value    tokens indices
0  room_number  11 F  eleven f  [2, 3]

>>> get_tokens('calling_room', "i'm in eleven f")
==========================================================================================================================================================================
     start      stop                                                                   entities                                                                      words
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.0       0.0                                                                       None                                                                        i'm
       0.0       0.0                                                                       None                                                                         in
       0.0       0.0                                                                        NUM                                                                     eleven
       0.0       0.0                                                                     LETTER                                                                          f
==========================================================================================================================================================================

>>> reload()

>>> stop()
Shutting down Discovery
discovery-dev
```