### PR TITLE
Avoid having to use print statements when using CLI SDK

### DIFF
--- a/cli_sdk.py
+++ b/cli_sdk.py
@@ -53,24 +53,30 @@ def log():
     log_discovery()
 
 
-def get_schema(intent, schema_key, transcript):
+def return_json_data(data, raw=False):
+    if raw:
+      return data
+    print(json.dumps(data, sort_keys=True, indent=2))
+
+
+def get_schema(intent, schema_key, transcript, raw_data=False):
     payload = submit_transcript(transcript, intent_whitelist=[intent])
     if schema_key in payload:
-        return json.dumps(payload[schema_key], sort_keys=True, indent=2)
+        return return_json_data(payload[schema_key], raw_data)
     else:
         return "Schema key {} not found".format(schema_key)
 
 
-def get_response(intent, transcript):
+def get_response(intent, transcript, raw_data=False):
     payload = submit_transcript(transcript, intent_whitelist=[intent])
-    return json.dumps(payload, sort_keys=True, indent=2)
+    return return_json_data(payload, raw_data)
 
 
 def get_entities(intent, transcript):
     payload = submit_transcript(transcript, intent_whitelist=[intent])
     entities = get_entities_from_discovery(payload)
     config = {"entities": [entity["label"] for entity in entities]}
-    return format_entities(entities, config)
+    print(format_entities(entities, config))
 
 
 def get_tokens(intent, transcript):
@@ -86,4 +92,4 @@ def get_tokens(intent, transcript):
             output.append(line)
         if separators == 2:
             break
-    return "\n".join(reversed(output))
+    print("\n".join(reversed(output)))


### PR DESCRIPTION
It was originally suggested in the original PR to allow users to retain the response from calls in the CLI SDK. However, because we want things pretty printed, this conflicts with the most often use case, which is simply seeing what the response is. 

To get things to print nicely in the current scheme, a user would have to wrap the calls in print statements themselves. If they don't, they'll get the raw response, but it'll be a string, so it's sort of useless anyways without parsing it back to JSON.

This PR reverts that behavior so that by default, everything just prints to the console. If desired, get_schema and get_response have an additional flag `raw_data`, which will return the raw_data for the query instead:

```
>>> a = get_response('calling_room', "i'm in eleven f", raw_data=True)
>>> a
{'transcript': "i'm in eleven f", 'intents': [{'label': 'calling_room', 'probability': 1.0, 'entities': [{'label': 'room_number', 'matches': [{'value': '11 F', 'probability': 1.0, 'lattice_path': [[2, 0, None], [3, 0, None]], 'startTimeSec': 0.0, 'endTimeSec': 0.0, 'interpreted_transcript': 'eleven f'}]}]}], 'calling_room': {'room_number': '11 F'}, 'identified_quotes': [], 'identified_trades': []}
```