### PR TITLE
sort glob result in test for consistent results across OS's

### DIFF
--- a/testing/parse_tests.py
+++ b/testing/parse_tests.py
@@ -9,10 +9,11 @@ from testing.discovery_config import DISABLE_INTENTS_WHITELIST
 def expand_wildcard_tests(directory, tests):
     """
     Expands any wildcard filenames in the list of tests
-    
-    >>> expand_wildcard_tests('examples/fruits', ['test*'])
+
+    >>> res = expand_wildcard_tests('examples/fruits', ['test*'])
+    >>> sorted(res)
     ['tests.txt', 'tests_negative.txt']
-    
+
     >>> expand_wildcard_tests('skip_this_directory', ['no_wildcards'])
     ['no_wildcards']
     """


### PR DESCRIPTION
`glob` can return files in different orders depending on the operating system, which can make this test flaky, so we sort the results for predictable test runs.