### PR TITLE
remove zero entity from examples

### DIFF
--- a/examples/directions/custom/definitions.yaml
+++ b/examples/directions/custom/definitions.yaml
@@ -25,13 +25,8 @@ entities:
   street_type:
     file: street_types.txt
     formatting: "entity.capitalize()"
-  zero:
-    - oh
-    - zero
-    - o
-    - formatting: "0"
   address_number:
-    - "(@zero|@num){1,5}"
+    - "@num{1,5}"
     - spacer: ''
   transportation_type:
     - foot

--- a/examples/directions/tests.txt
+++ b/examples/directions/tests.txt
@@ -22,7 +22,7 @@ transcript: Take me to three zero two wacker drive
 complete_address: 302 Wacker Drive
 
 test: directions with zero-indicated word
-transcript: Take me to four o two wacker drive
+transcript: Take me to four oh two wacker drive
 complete_address: 402 Wacker Drive
 
 test: directions with complex zero patterns


### PR DESCRIPTION
this was confusing since `@num` has coverage of everything except the letter `o`