### PR TITLE
allow tests to reference external entities

### DIFF
--- a/test_discovery.py
+++ b/test_discovery.py
@@ -73,10 +73,11 @@ def test_one(test_dict, intent_whitelist, domain_whitelist):
     intent_results = {}
 
     test_name, transcript = test_dict["test"], test_dict["transcript"]
+    external_entities = test_dict.get("external_entities")
 
     # Timing submit_transcript function
     test_start_time = time.time()
-    resp = submit_transcript(transcript, intent_whitelist, domain_whitelist)
+    resp = submit_transcript(transcript, intent_whitelist, domain_whitelist, external_entities)
     test_end_time = time.time()
 
     time_dif_ms = 1000 * (test_end_time - test_start_time)
@@ -99,7 +100,7 @@ def test_one(test_dict, intent_whitelist, domain_whitelist):
     intent_results["expected_entities"] = {
         k: v
         for k, v in test_dict.items()
-        if k not in ['test', 'transcript', 'schema', 'intent']
+        if k not in ['test', 'transcript', 'schema', 'intent', 'external_entities']
     }
     intent_results["observed_entities"] = \
         entity_results['observed_entity_dict']

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -67,7 +67,8 @@ def wait_for_discovery_launch():
     # Timeout of 25 seconds for launch
     if not wait_for_discovery_status():
         LOGGER.error("Couldn't launch Discovery, printing Docker logs:\n---\n")
-        docker_log_and_stop()
+        log_discovery()
+        shutdown_discovery()
         sys.exit(1)
     else:
         print("Discovery Launched!")
@@ -108,7 +109,7 @@ def setup_discovery(directory, custom_directory, domains):
     return volume
 
 
-def submit_transcript(transcript, intent_whitelist=["any"], domain_whitelist=["any"]):
+def submit_transcript(transcript, intent_whitelist=["any"], domain_whitelist=["any"], external_entities=None):
     """
     Submits a transcript to Discovery
     :param transcript: str,
@@ -120,6 +121,8 @@ def submit_transcript(transcript, intent_whitelist=["any"], domain_whitelist=["a
         "intents": intent_whitelist,
         "domains": domain_whitelist,
     }
+    if external_entities is not None:
+        payload['entities'] = external_entities
     response = requests.post(DISCOVERY_URL, json=payload)
     if not response.status_code == 200:
         LOGGER.error("Request was not successful. Response Status Code: {}".format(

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -281,12 +281,12 @@ def evaluate_entities_and_schema(test_dict, resp, verbose=False, intent=0):
         for ent in entities
     }
 
-    test_name = test_dict.get('test', '')
+    test_name = test_dict.get('test', 'Unnamed Test')
 
     # Remove non-entity keys from test_dict, then pass to `test_single_case`
     test_dict = {
         k: v
-        for k, v in test_dict.items() if not k in ['transcript', 'intent', 'test']
+        for k, v in test_dict.items() if k not in ['transcript', 'intent', 'test', 'external_entities']
     }
     # evaluate whether all expected entities (label/value) are found in observed entity dict returned fby Discovery
     return test_single_case(test_dict, observed_entity_dict, resp, test_name)


### PR DESCRIPTION
Add code to enable external entities for use with discovery SDK tests. From conversations with Matthew, we decided it was best to forgo adding public-facing tests for now.

View [this PR])https://github.com/greenkeytech/greenkey-discovery-sdk-private/pull/533) for more description of the feature.