### PR TITLE
provide CI checks to ensure single yaml files do not contain duplicate keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,6 @@ script:
   - python3 -m pytest .tests/test_all_yaml_files_load.py -s
   - python3 -m pytest --doctest-modules util testing
   - python3 testing/metrics.py
+  # validate no duplicate keys in yaml using yamllint
+  - python3 -m yamllint .
 

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  braces: disable
+  brackets: disable
+  colons: disable
+  commas: disable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: disable
+  empty-values: disable
+  hyphens: disable
+  indentation: disable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: disable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: disable
+  truthy:
+    level: warning

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fire
 pytest
 exrex
 streamlit
+yamllint


### PR DESCRIPTION
This should help other developers catch common mistakes more quickly