### PR TITLE
allow for arbitrary JSON injection in tests to test integration with other services

### DIFF
--- a/test_discovery.py
+++ b/test_discovery.py
@@ -73,11 +73,11 @@ def test_one(test_dict, intent_whitelist, domain_whitelist):
     intent_results = {}
 
     test_name, transcript = test_dict["test"], test_dict["transcript"]
-    external_entities = test_dict.get("external_entities")
+    external_json = test_dict.get("external_json")
 
     # Timing submit_transcript function
     test_start_time = time.time()
-    resp = submit_transcript(transcript, intent_whitelist, domain_whitelist, external_entities)
+    resp = submit_transcript(transcript, intent_whitelist, domain_whitelist, external_json)
     test_end_time = time.time()
 
     time_dif_ms = 1000 * (test_end_time - test_start_time)
@@ -100,7 +100,7 @@ def test_one(test_dict, intent_whitelist, domain_whitelist):
     intent_results["expected_entities"] = {
         k: v
         for k, v in test_dict.items()
-        if k not in ['test', 'transcript', 'schema', 'intent', 'external_entities']
+        if k not in ['test', 'transcript', 'schema', 'intent', 'external_json']
     }
     intent_results["observed_entities"] = \
         entity_results['observed_entity_dict']

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -109,7 +109,7 @@ def setup_discovery(directory, custom_directory, domains):
     return volume
 
 
-def submit_transcript(transcript, intent_whitelist=["any"], domain_whitelist=["any"], external_entities=None):
+def submit_transcript(transcript, intent_whitelist=["any"], domain_whitelist=["any"], external_json=None):
     """
     Submits a transcript to Discovery
     :param transcript: str,
@@ -121,8 +121,11 @@ def submit_transcript(transcript, intent_whitelist=["any"], domain_whitelist=["a
         "intents": intent_whitelist,
         "domains": domain_whitelist,
     }
-    if external_entities is not None:
-        payload['entities'] = external_entities
+
+    # merge with file json when given
+    if external_json is not None:
+        payload = {**external_json, **payload}
+
     response = requests.post(DISCOVERY_URL, json=payload)
     if not response.status_code == 200:
         LOGGER.error("Request was not successful. Response Status Code: {}".format(

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -286,7 +286,7 @@ def evaluate_entities_and_schema(test_dict, resp, verbose=False, intent=0):
     # Remove non-entity keys from test_dict, then pass to `test_single_case`
     test_dict = {
         k: v
-        for k, v in test_dict.items() if k not in ['transcript', 'intent', 'test', 'external_entities']
+        for k, v in test_dict.items() if k not in ['transcript', 'intent', 'test', 'external_json']
     }
     # evaluate whether all expected entities (label/value) are found in observed entity dict returned fby Discovery
     return test_single_case(test_dict, observed_entity_dict, resp, test_name)

--- a/testing/parse_tests.py
+++ b/testing/parse_tests.py
@@ -87,12 +87,12 @@ def parse_test_line(ret_dict, key, value, test_folder):
    """
    Modify the dictionary in place because code climate thinks this is less complex
    """
-   if key not in ['test', 'external_entities', 'transcript']:
+   if key not in ['test', 'external_json', 'transcript']:
        # keys that define expected output of discovery
        ret_dict['expected_outputs'] = ret_dict.get('expected_outputs', []) + [(key, value)] 
-   elif key == 'external_entities':
-       ent_file = join_path(test_folder, 'external_entities', value)
-       ret_dict[key] = json.load(open(ent_file, 'r'))['entities']
+   elif key == 'external_json':
+       ent_file = join_path(test_folder, 'external_json', value)
+       ret_dict[key] = json.load(open(ent_file, 'r'))
    else:
        # Unique keys (per test set) that are test definition parameters usually
        ret_dict[key] = value


### PR DESCRIPTION
In order to ingest extra keys other than the transcript, we want to be able to inject arbitrary JSON to our test payloads.