### PR TITLE
Improve logging of discovery startup to catch errors

### DIFF
--- a/cli_sdk.py
+++ b/cli_sdk.py
@@ -52,8 +52,9 @@ def restart():
     start()
 
 
-def log():
-    log_discovery()
+def log(previous_logs=''):
+    logs = log_discovery(previous_logs)
+    return logs
 
 
 def return_json_data(data, raw=False):

--- a/launch_discovery.py
+++ b/launch_discovery.py
@@ -105,7 +105,7 @@ def _launch_container(custom_directory, port, discovery_config, container_name):
         volume = custom_directory
 
     launch_command = " ".join(
-        ["docker", "run", "--rm", "-d"] + ["--name", container_name] +
+        ["docker", "run", "-d"] + ["--name", container_name] +
         ["-v", "{}:/custom".format(volume)] +
         ["-p", "{}:{}".format(port, discovery_config["PORT"])] + dico_dir
         # + model_dir

--- a/testing/discovery_config.py
+++ b/testing/discovery_config.py
@@ -5,8 +5,8 @@ DISCOVERY_PORT = "1234"
 DISCOVERY_HOST = "localhost"
 TAG = os.environ.get("TAG", "latest")
 
-TIMEOUT = int(os.environ.get('DISCOVERY_TIMEOUT', '20'))
-RETRIES = int(os.environ.get('DISCOVERY_RETRIES', '15'))
+TIMEOUT = int(os.environ.get('DISCOVERY_TIMEOUT', '5'))
+RETRIES = int(os.environ.get('DISCOVERY_RETRIES', '60'))
 
 DISABLE_INTENTS_WHITELIST = False
 

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -85,8 +85,7 @@ def wait_for_discovery_status():
     for attempt_number in range(RETRIES):
         if try_discovery(attempt_number):
             return True
-        else:
-            full_logs = print_logs(full_logs)
+        full_logs = print_logs(full_logs)
         if not discovery_container_is_running():
             return False
     return False

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -63,10 +63,18 @@ def try_discovery(attempt_number):
         check_discovery_status()
         return True
     except Exception:
-        if attempt_number >= 15:
+        if attempt_number >= RETRIES / 4:
             LOGGER.error("Could not reach discovery, attempt {0} of {1}".format(
                 attempt_number + 1, RETRIES))
         time.sleep(TIMEOUT)
+
+
+def print_logs(full_logs):
+    incremental_logs = log_discovery(full_logs)
+    full_logs += incremental_logs
+    if incremental_logs:
+        print(incremental_logs)
+    return full_logs
 
 
 def wait_for_discovery_status():
@@ -78,10 +86,7 @@ def wait_for_discovery_status():
         if try_discovery(attempt_number):
             return True
         else:
-            incremental_logs = log_discovery(full_logs)
-            full_logs += incremental_logs
-            if incremental_logs:
-                print(incremental_logs)
+            full_logs = print_logs(full_logs)
         if not discovery_container_is_running():
             return False
     return False


### PR DESCRIPTION
This PR incrementally logs discovery on startup to catch errors easily. This involves changing the container launch to not be removed automatically. If the shutdown discovery interface is used, everything is cleaned up nicely. But if discovery is stopped outside of these interfaces and not removed, then the first launch command after will fail (but will cleanup the previously leftover container for future successful launches).

Behavior with no errors:

```
>>> start()
Limiting domains to calling_room
Launching Discovery from Container: docker run -d --name discovery-dev -v /Users/tejasshastry/GreenKey/devRepositories/greenkey-discovery-sdk/examples/calling_room/custom:/custom -p 1234:1234 -e LICENSE_KEY=[redacted] -e NUMBER_OF_INTENTS=1 -e MAX_NUMBER_OF_ENTITIES=100 -e LOG_LEVEL=debug -e TRAIN_MODELS=False -e SUPPRESS_DEFAULT_OUTPUT=False -e PORT=1234 -e DISCOVERY_DOMAINS=calling_room docker.greenkeytech.com/discovery:latest

10cb342e77d579644dc2bf1a8206f239f47c53847826be28fc779421315326a1
The following entities were declared, but were not implemented in any search patterns: {'n_day_token', 'MODIFIER', 'test', 'eqd_imstring', 'iron_imstring', 'down', 'stopword', 'n_week_token', 'to_blank', 'pos_or_neg', 'fra_contract_pair_token', 'preposition', 'bor_str'} They will not be searched for by Discovery.
INFO     - 2020-09-03 14:54:18,567 - root - Logger initialized! Threshold set to "DEBUG".
INFO     - 2020-09-03 14:54:18,568 - bjoern_wsgi - Starting up discovery server on port 1234
Discovery Launched!
```

---

Behavior with errors:

```
>>> start()
Limiting domains to calling_room
Launching Discovery from Container: docker run -d --name discovery-dev -v /Users/tejasshastry/GreenKey/devRepositories/greenkey-discovery-sdk/examples/calling_room/custom:/custom -p 1234:1234 -e LICENSE_KEY=[redacted] -e NUMBER_OF_INTENTS=1 -e MAX_NUMBER_OF_ENTITIES=100 -e LOG_LEVEL=debug -e TRAIN_MODELS=False -e SUPPRESS_DEFAULT_OUTPUT=False -e PORT=1234 -e DISCOVERY_DOMAINS=calling_room docker.greenkeytech.com/discovery:latest

fe22172f51c05e90a3b9f6a56ff36eafded6f6ec66467405fa69325be45688a5
Traceback (most recent call last):
  File "discovery/discovery_utils/definition_parser/yaml_definition_file_parser.py", line 81, in discovery.discovery_utils.definition_parser.yaml_definition_file_parser._convert_yaml_to_map_object
  File "dist.py", line 98, in dist.decrypt
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/Crypto/Cipher/_mode_cbc.py", line 246, in decrypt
    raise ValueError("Data must be padded to %d byte boundary in CBC mode" % self.block_size)
ValueError: Data must be padded to 16 byte boundary in CBC mode

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "discovery/bjoern_wsgi.py", line 18, in init discovery.bjoern_wsgi
  File "discovery/server.py", line 18, in init discovery.server
  File "discovery/server_utils.py", line 18, in init discovery.server_utils
  File "discovery/process.py", line 12, in init discovery.process
  File "discovery/data_processor.py", line 10, in init discovery.data_processor
  File "discovery/discovery_utils/schema_parser.py", line 13, in init discovery.discovery_utils.schema_parser
  File "discovery/discovery_utils/schema_utils.py", line 13, in init discovery.discovery_utils.schema_utils
  File "discovery/discovery_utils/heuristic.py", line 15, in init discovery.discovery_utils.heuristic
  File "/scribe/discovery/discovery_utils/definition_parser/__init__.py", line 4, in <module>
    from .domain_initializer import create_dict_of_initialized_domains
  File "discovery/discovery_utils/definition_parser/domain_initializer.py", line 12, in init discovery.discovery_utils.definition_parser.domain_initializer
  File "discovery/domains/domain.py", line 10, in init discovery.domains.domain
  File "discovery/domains/random_example_generator.py", line 20, in init discovery.domains.random_example_generator
  File "discovery/discovery_utils/definition_parser/definition_parser.py", line 21, in discovery.discovery_utils.definition_parser.definition_parser.get_discovery_definitions
  File "discovery/discovery_utils/definition_parser/unformatted_definition_dict.py", line 48, in discovery.discovery_utils.definition_parser.unformatted_definition_dict.get_discovery_definitions_dict
  File "discovery/discovery_utils/definition_parser/unformatted_definition_dict.py", line 100, in discovery.discovery_utils.definition_parser.unformatted_definition_dict._read_definition_files
  File "discovery/discovery_utils/definition_parser/yaml_definition_file_parser.py", line 49, in discovery.discovery_utils.definition_parser.yaml_definition_file_parser.read_and_normalize_yaml_definition_file
  File "cytoolz/functoolz.pyx", line 669, in cytoolz.functoolz.pipe
  File "cytoolz/functoolz.pyx", line 644, in cytoolz.functoolz.c_pipe
  File "discovery/discovery_utils/definition_parser/yaml_definition_file_parser.py", line 83, in discovery.discovery_utils.definition_parser.yaml_definition_file_parser._convert_yaml_to_map_object
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/scribe/discovery_venv/.venv/lib/python3.7/site-packages/yaml/parser.py", line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "<byte string>", line 5, column 5:
        domain: calling_room
        ^
expected <block end>, but found '<block mapping start>'
  in "<byte string>", line 11, column 7:
          schema:
          ^
Couldn't launch Discovery
Shutting down Discovery
discovery-dev
```