### PR TITLE
Print all entities by default using pandas print options. 

### DIFF
--- a/interactive_sdk.py
+++ b/interactive_sdk.py
@@ -19,6 +19,9 @@ ENCODING = "utf-8"
 DISCOVERY_DOMAINS = os.environ.get('DISCOVERY_DOMAINS', '').split(',')
 DISCOVERY_INTENTS = os.environ.get('DISCOVERY_INTENTS', '').split(',')
 
+# None here prints all datafram rows
+pd.set_option('display.max_rows', int(os.environ.get('DISCOVERY_DISPLAY_ROWS')))
+
 DOMAIN_WHITELIST = DISCOVERY_DOMAINS + ["any"]
 INTENT_WHITELIST = DISCOVERY_INTENTS + ["any"]
 


### PR DESCRIPTION
Add DISCOVERY_DISPLAY_ROWS in case users don't want all entities printed.

Before
![image](https://user-images.githubusercontent.com/24980609/94583939-a50ba400-0243-11eb-8db1-b9638a7175a7.png)

After (output continues to row 105)
![image](https://user-images.githubusercontent.com/24980609/94584013-b81e7400-0243-11eb-81e2-7894c63263c7.png)
