### PR TITLE
Fix test discovery with duplicate transcript and key,value search

### DIFF
--- a/testing/discovery_config.py
+++ b/testing/discovery_config.py
@@ -36,6 +36,9 @@ DISCOVERY_CONFIG = {
 
     # Port that Discovery will bind to on the Docker daemon, change if port is taken already
     "PORT": DISCOVERY_PORT,
+
+    # Prune output lattice (remove word_confusions and alternates)
+    "PRUNE_LATTICE": True,
 }
 
 # only set if present since defaults would otherwise be long and should not be maintained here

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -163,11 +163,7 @@ def submit_transcript(transcript,
 
     # merge with file json when given
     if external_json is not None:
-        # having "transcript" at the top level of payload caused issues for input gk json that contain "segments"
-        # nlprocessor_earnings_call_test_1.json contains a transcript in segments[0]['transcript'] and discovery output
-        # was missing interpreted_fields.
-        # remove the conflicting transcript key below. The other external_json tests contain "transcript" at the top, so
-        # it is present and tests work
+        # remove the conflicting transcript key below. The external_json tests already contain "transcript"
         del payload["transcript"]
         payload = {**external_json, **payload}
 

--- a/testing/discovery_interface.py
+++ b/testing/discovery_interface.py
@@ -163,6 +163,12 @@ def submit_transcript(transcript,
 
     # merge with file json when given
     if external_json is not None:
+        # having "transcript" at the top level of payload caused issues for input gk json that contain "segments"
+        # nlprocessor_earnings_call_test_1.json contains a transcript in segments[0]['transcript'] and discovery output
+        # was missing interpreted_fields.
+        # remove the conflicting transcript key below. The other external_json tests contain "transcript" at the top, so
+        # it is present and tests work
+        del payload["transcript"]
         payload = {**external_json, **payload}
 
     response = requests.post(DISCOVERY_URL, json=payload)

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -62,37 +62,37 @@ def _find(obj, key):
 def is_invalid_schema(schema, test_value):
     """
     Checks schema against tests with dictionary nesting
-    
+
     >>> is_invalid_schema({"valid_key": "some_value"}, {"valid_key": "some_value"})
     False
-    
+
     >>> is_invalid_schema({"invalid_key": "some_value"}, {"valid_key": "some_value"})
     True
-    
+
     >>> is_invalid_schema(
     ... {"nested": {"valid_key": "some_value", "another_key": "some_value"}},
     ... {"nested": {"valid_key": "some_value"}}
     ... )
     False
-    
+
     >>> is_invalid_schema(
     ... {"nested": {"invalid_key": "some_value", "another_key": "some_value"}},
     ... {"nested": {"valid_key": "some_value"}}
     ... )
     True
-    
+
     >>> is_invalid_schema(
     ... {"nested": {"valid_key": "some_invalid_value", "another_key": "some_value"}},
     ... {"nested": {"valid_key": "some_value"}}
     ... )
     True
-    
+
     >>> is_invalid_schema(
     ... {"nested": {"double": {"valid_key": "some_value", "another_key": "some_value"}}},
     ... {"nested": {"double": {"valid_key": "some_value"}}}
     ... )
     False
-    
+
     >>> is_invalid_schema(
     ... {"nested": {"double": {"valid_key": "some_value", "another_key": "some_value"}}},
     ... {"nested": {"double": {"valid_key": "some_value"}, "some_key": "no_value"}}
@@ -112,6 +112,24 @@ def test_schema(full_response, test_value, test_name=''):
     recursively search the JSON response for the key,
     then make sure the value is correct
     """
+
+    # Exclude word_confusions from the search below. There was an error when the word was the same as a return_json key
+    # segment['word_confusions'] =
+    #   [{'AMD': 1},
+    #   {'had': 1},
+    #    ...
+    #   {'revenue': 1},
+    # and
+    # interpreted_fields:
+    #       company_name: '@nlprocessor_company_name'
+    #       key_metrics:
+    #         revenue:
+    #
+    # the revenue key metric was never found since the word confusion {'revenue':1} was found first
+
+    # assume there is only one segment since that's how the tests are written
+    if full_response.get('segments') and full_response.get('segments')[0].get('word_confusions'):
+        del full_response['segments'][0]['word_confusions']
 
     # Returning number of errors, so check for values that do not equal test case
     errs = {}
@@ -174,7 +192,7 @@ def print_extra_entities(observed_entity_dict, test_dict, test_name=''):
 
 
 """
-Intent tests      
+Intent tests
 """
 
 
@@ -209,7 +227,7 @@ def format_intent_test_result(test_name, expected_intent, observed_intent):
 
 
 """
-Evaluate entity and schema tests    
+Evaluate entity and schema tests
 """
 
 

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -114,21 +114,8 @@ def test_schema(full_response, test_value, test_name=''):
     """
 
     # Exclude word_confusions from the search below. There was an error when the word was the same as a return_json key
-    # segment['word_confusions'] =
-    #   [{'AMD': 1},
-    #   {'had': 1},
-    #    ...
-    #   {'revenue': 1},
-    # and
-    # interpreted_fields:
-    #       company_name: '@nlprocessor_company_name'
-    #       key_metrics:
-    #         revenue:
-    #
-    # the revenue key metric was never found since the word confusion {'revenue':1} was found first
-
     # assume there is only one segment since that's how the tests are written
-    if full_response.get('segments') and full_response.get('segments')[0].get('word_confusions'):
+    if full_response.get('segments', [{}])[0].get('word_confusions'):
         del full_response['segments'][0]['word_confusions']
 
     # Returning number of errors, so check for values that do not equal test case
@@ -146,7 +133,6 @@ def test_schema(full_response, test_value, test_name=''):
         logger.info("Test {0} - Full response is {1}".format(test_name, full_response))
 
     return len(errs), json.dumps(errs)
-
 
 """
 Entity tests

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -113,11 +113,6 @@ def test_schema(full_response, test_value, test_name=''):
     then make sure the value is correct
     """
 
-    # Exclude word_confusions from the search below. There was an error when the word was the same as a return_json key
-    # assume there is only one segment since that's how the tests are written
-    if full_response.get("segments", [{}])[0].get("word_confusions"):
-        del full_response["segments"][0]["word_confusions"]
-
     # Returning number of errors, so check for values that do not equal test case
     errs = {}
     for res in map(

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -115,8 +115,8 @@ def test_schema(full_response, test_value, test_name=''):
 
     # Exclude word_confusions from the search below. There was an error when the word was the same as a return_json key
     # assume there is only one segment since that's how the tests are written
-    if full_response.get('segments', [{}])[0].get('word_confusions'):
-        del full_response['segments'][0]['word_confusions']
+    if full_response.get("segments", [{}])[0].get("word_confusions"):
+        del full_response["segments"][0]["word_confusions"]
 
     # Returning number of errors, so check for values that do not equal test case
     errs = {}
@@ -149,7 +149,7 @@ def test_single_entity(entities, entity_label, test_value, test_name=''):
     """
     if entity_label not in entities.keys():
         logger.info("Test {0} - Entity not found: {1}".format(test_name, entity_label))
-        return 1, '[value missing]'
+        return 1, "[value missing]"
 
     if entities[entity_label] != test_value:
         logger.info(
@@ -157,7 +157,7 @@ def test_single_entity(entities, entity_label, test_value, test_name=''):
             format(test_name, entity_label, test_value, entities[entity_label]))
         return 1, entities[entity_label]
 
-    return 0, ''
+    return 0, ""
 
 
 def print_extra_entities(observed_entity_dict, test_dict, test_name=''):
@@ -208,7 +208,7 @@ def evaluate_intent(test_dict, resp, test_name=''):
 def format_intent_test_result(test_name, expected_intent, observed_intent):
     return dict(expected_intent=expected_intent,
                 observed_intent=observed_intent,
-                test_failures=([test_name, 'intent', expected_intent, observed_intent]
+                test_failures=([test_name, "intent", expected_intent, observed_intent]
                                if expected_intent != observed_intent else []))
 
 
@@ -285,12 +285,12 @@ def evaluate_entities_and_schema(test_dict, resp, verbose=False, intent=0):
         for ent in entities
     }
 
-    test_name = test_dict.get('test', 'Unnamed Test')
+    test_name = test_dict.get("test", "Unnamed Test")
 
     # Remove non-entity keys from test_dict, then pass to `test_single_case`
     test_dict = {
         k: v
-        for k, v in test_dict.items() if k not in ['transcript', 'intent', 'test', 'external_json']
+        for k, v in test_dict.items() if k not in ["transcript", "intent", "test", "external_json"]
     }
     # evaluate whether all expected entities (label/value) are found in observed entity dict returned fby Discovery
     return test_single_case(test_dict, observed_entity_dict, resp, test_name)


### PR DESCRIPTION
Issues fixed when using the integration tests with json input

ensure no duplicate 'transcript' key is present
do not search key,values in word_confusions