### PR TITLE
add logging of errors for interpreter testing to file

### DIFF
--- a/test_nlp.py
+++ b/test_nlp.py
@@ -30,7 +30,7 @@ logging.basicConfig(
 LOGGER = logging.getLogger(__name__)
 
 # create filehandler just for test errors for ease of human review
-error_log=logging.FileHandler("test_output.log","w+")
+error_log = logging.FileHandler("test_output.log", "w+")
 error_log.setLevel(logging.ERROR)
 
 LOGGER.addHandler(error_log)
@@ -52,25 +52,16 @@ def format_bad_response(test_name, message, resp):
     return f"Test {test_name} - Failed: {message}. Response: {resp}"
 
 
-def format_bad_entities(test_name, test_dict, test_results):
+def format_bad_entities(test_name, test_results):
     """
     Format error for pytest output
     """
-    expected_output = {
-        k: v
-        for k, v in test_dict.items() if k not in [
-            "test",
-            "transcript",
-            "schema",
-            "intent",
-            "external_json",
-            "predicted_intent",
-        ]
-    }
-    msg = f"\n{test_name}\nExpected: {expected_output}\nReceived: {test_results['observed_entity_dict']}"
-    if "predicted_intent" in test_dict:
-        msg += (f"\nExpected intent: {test_dict['predicted_intent']}\n" +
-                f"Observed intents:{test_results['observed_intents']}")
+    entity_failures = ", ".join(failure[1] for failure in test_results["test_failures"])
+    msg = f"{test_name} failed for entities: {entity_failures}\n"
+    for failure in test_results["test_failures"]:
+        msg += "\n"
+        msg += f"Expected {failure[1]}: {failure[2]}\n"
+        msg += f"Observed {failure[1]}: {failure[3]}"
     LOGGER.error(msg)
     return msg
 
@@ -80,7 +71,7 @@ def test_nlp_stack(test_dict, intents, nlp_models, test_name):
     Test a single test dict with both nlprocessor and discovery
     """
     test_dict = test_dict.copy()
-    _, transcript = test_dict.pop("test"), test_dict.pop("transcript")
+    transcript = test_dict.pop("transcript")
     external_json = test_dict.get("external_json", {})
 
     resp = {}
@@ -101,8 +92,8 @@ def test_nlp_stack(test_dict, intents, nlp_models, test_name):
     # Check entity tests
     test_results = evaluate_entities_and_schema(test_dict, resp)
 
-    assert test_results.get("total_errors") in {0, None}, format_bad_entities(test_name,
-        test_dict, test_results)
+    assert test_results.get("total_errors") in {0, None}, format_bad_entities(
+        test_name, test_results)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/test_nlp.py
+++ b/test_nlp.py
@@ -28,13 +28,6 @@ logging.basicConfig(
 )
 
 LOGGER = logging.getLogger(__name__)
-
-# create filehandler just for test errors for ease of human review
-error_log = logging.FileHandler("test_output.log", "w+")
-error_log.setLevel(logging.ERROR)
-
-LOGGER.addHandler(error_log)
-
 env = dotenv.dotenv_values("client.env")
 
 # enable LRU caching if a test transcript and arguments are duplicated
@@ -56,13 +49,11 @@ def format_bad_entities(test_name, test_results):
     """
     Format error for pytest output
     """
-    entity_failures = ", ".join(failure[1] for failure in test_results["test_failures"])
-    msg = f"{test_name} failed for entities: {entity_failures}\n"
+    msg = f"{test_name}\n"
     for failure in test_results["test_failures"]:
-        msg += "\n"
         msg += f"Expected {failure[1]}: {failure[2]}\n"
-        msg += f"Observed {failure[1]}: {failure[3]}"
-    LOGGER.error(msg)
+        msg += f"Observed {failure[1]}: {failure[3]}\n"
+
     return msg
 
 

--- a/test_nlp.py
+++ b/test_nlp.py
@@ -101,7 +101,7 @@ def test_nlp_stack(test_dict, intents, nlp_models, test_name):
     # Check entity tests
     test_results = evaluate_entities_and_schema(test_dict, resp)
 
-    assert test_results.get("total_errors") in {0, None}, format_bad_entities(
+    assert test_results.get("total_errors") in {0, None}, format_bad_entities(test_name,
         test_dict, test_results)
 
 

--- a/test_nlp.py
+++ b/test_nlp.py
@@ -28,6 +28,13 @@ logging.basicConfig(
 )
 
 LOGGER = logging.getLogger(__name__)
+
+# create filehandler just for test errors for ease of human review
+error_log=logging.FileHandler("test_output.log","w+")
+error_log.setLevel(logging.ERROR)
+
+LOGGER.addHandler(error_log)
+
 env = dotenv.dotenv_values("client.env")
 
 # enable LRU caching if a test transcript and arguments are duplicated
@@ -45,7 +52,7 @@ def format_bad_response(test_name, message, resp):
     return f"Test {test_name} - Failed: {message}. Response: {resp}"
 
 
-def format_bad_entities(test_dict, test_results):
+def format_bad_entities(test_name, test_dict, test_results):
     """
     Format error for pytest output
     """
@@ -60,11 +67,11 @@ def format_bad_entities(test_dict, test_results):
             "predicted_intent",
         ]
     }
-    msg = f"\nExpected: {expected_output}\nReceived: {test_results['observed_entity_dict']}"
+    msg = f"\n{test_name}\nExpected: {expected_output}\nReceived: {test_results['observed_entity_dict']}"
     if "predicted_intent" in test_dict:
         msg += (f"\nExpected intent: {test_dict['predicted_intent']}\n" +
                 f"Observed intents:{test_results['observed_intents']}")
-
+    LOGGER.error(msg)
     return msg
 
 

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -8,6 +8,14 @@ import json
 from datetime import date
 
 from testing.format_tests import strip_extra_whitespace
+
+# create filehandler just for test errors for ease of human review
+error_log = logging.FileHandler("test_output.log", "w+")
+error_log.setLevel(logging.ERROR)
+
+logger.addHandler(error_log)
+
+
 """
 Helper functions
 """
@@ -113,9 +121,11 @@ def test_schema(resp, test_value, test_name=""):
         errs.update(res)
 
     if errs:
-        logger.info("Test {0} - Schema test failed for {1} with response {2}".format(
-            test_name, test_value, errs))
-        logger.info("Test {0} - Full response is {1}".format(test_name, resp))
+        logger.info(f"Test {test_name} - Schema test failed for {test_value} with response {errs}")
+        logger.error(test_name)
+        for key in errs.keys():
+            logger.error(f"Expected {key}: {test_value[key]}")
+            logger.error(f"Observed {key}: {errs[key]}\n")
 
     return len(errs), json.dumps(errs)
 
@@ -298,8 +308,6 @@ def test_single_case(test_dict, resp, test_name=""):
     test_failures, new_errors = check_entities(test_dict, resp, test_name,
                                                observed_entity_dict)
     total_errors += new_errors
-
-    print_extra_entities(observed_entity_dict, test_dict, test_name)
 
     return dict(
         total_errors=total_errors,

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -11,11 +11,9 @@ error_log = logging.FileHandler("test_output.log", "w+")
 error_log.setLevel(logging.ERROR)
 logger.addHandler(error_log)
 
-
 """
 Helper functions
 """
-
 
 def is_valid_response(resp):
     """
@@ -28,7 +26,6 @@ def is_valid_response(resp):
 """
 Schema tests
 """
-
 
 def _find_in_list(obj, key):
     for list_item in obj:

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -6,11 +6,11 @@ from datetime import date
 from testing.format_tests import strip_extra_whitespace
 from testing.output_tests import print_errors
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 # create filehandler just for test errors for ease of human review
 error_log = logging.FileHandler("test_output.log", "w+")
 error_log.setLevel(logging.ERROR)
-logger.addHandler(error_log)
+LOGGER.addHandler(error_log)
 
 """
 Helper functions
@@ -114,7 +114,7 @@ def test_schema(resp, test_value, test_name=""):
     ):
         errs.update(res)
 
-    print_errors(test_name, test_value, errs, logger)
+    print_errors(test_name, test_value, errs, LOGGER)
 
     return len(errs), json.dumps(errs)
 
@@ -133,11 +133,11 @@ def test_single_entity(entities, entity_label, test_value, test_name=""):
     :param test_name: str
     """
     if entity_label not in entities.keys():
-        logger.info("Test {0} - Entity not found: {1}".format(test_name, entity_label))
+        LOGGER.info("Test {0} - Entity not found: {1}".format(test_name, entity_label))
         return 1, "[value missing]"
 
     if entities[entity_label] != test_value:
-        logger.info(
+        LOGGER.info(
             "Test {0} - Observed Entity Value Incorrect: ({1}) Expected {2} != {3}".
             format(test_name, entity_label, test_value, entities[entity_label]))
         return 1, entities[entity_label]
@@ -159,7 +159,7 @@ def print_extra_entities(observed_entity_dict, test_dict, test_name=""):
     }
 
     if extra_entities:
-        logger.info("Test {0} - Extra entities: {1}".format(test_name, extra_entities))
+        LOGGER.info("Test {0} - Extra entities: {1}".format(test_name, extra_entities))
 
 
 """
@@ -183,7 +183,7 @@ def evaluate_intent(test_dict, resp, test_name=""):
     failed_test = 0 if expected_intent == observed_intent else 1
 
     if failed_test:
-        logger.info(
+        LOGGER.info(
             "Test {0} - Observed intent {1} does not match expected intent {2}".format(
                 test_name, observed_intent, expected_intent))
 

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python3
 
 import logging
-
-logger = logging.getLogger(__name__)
-
 import json
 from datetime import date
-
 from testing.format_tests import strip_extra_whitespace
 
+logger = logging.getLogger(__name__)
 # create filehandler just for test errors for ease of human review
 error_log = logging.FileHandler("test_output.log", "w+")
 error_log.setLevel(logging.ERROR)
-
 logger.addHandler(error_log)
 
 
@@ -104,6 +100,15 @@ def is_invalid_schema(schema, test_value):
     return schema != test_value
 
 
+def print_errors(test_name, test_value, errs):
+    if errs:
+        logger.info(f"Test {test_name} - Schema test failed for {test_value} with response {errs}")
+        logger.error(test_name)
+        for key in errs.keys():
+            logger.error(f"Expected {key}: {test_value[key]}")
+            logger.error(f"Observed {key}: {errs[key]}\n")
+
+
 def test_schema(resp, test_value, test_name=""):
     """
     For each key-value pair given in the schema test,
@@ -120,12 +125,7 @@ def test_schema(resp, test_value, test_name=""):
     ):
         errs.update(res)
 
-    if errs:
-        logger.info(f"Test {test_name} - Schema test failed for {test_value} with response {errs}")
-        logger.error(test_name)
-        for key in errs.keys():
-            logger.error(f"Expected {key}: {test_value[key]}")
-            logger.error(f"Observed {key}: {errs[key]}\n")
+    print_errors(test_name, test_value, errs)
 
     return len(errs), json.dumps(errs)
 

--- a/testing/evaluate_tests.py
+++ b/testing/evaluate_tests.py
@@ -4,6 +4,7 @@ import logging
 import json
 from datetime import date
 from testing.format_tests import strip_extra_whitespace
+from testing.output_tests import print_errors
 
 logger = logging.getLogger(__name__)
 # create filehandler just for test errors for ease of human review
@@ -97,15 +98,6 @@ def is_invalid_schema(schema, test_value):
     return schema != test_value
 
 
-def print_errors(test_name, test_value, errs):
-    if errs:
-        logger.info(f"Test {test_name} - Schema test failed for {test_value} with response {errs}")
-        logger.error(test_name)
-        for key in errs.keys():
-            logger.error(f"Expected {key}: {test_value[key]}")
-            logger.error(f"Observed {key}: {errs[key]}\n")
-
-
 def test_schema(resp, test_value, test_name=""):
     """
     For each key-value pair given in the schema test,
@@ -122,7 +114,7 @@ def test_schema(resp, test_value, test_name=""):
     ):
         errs.update(res)
 
-    print_errors(test_name, test_value, errs)
+    print_errors(test_name, test_value, errs, logger)
 
     return len(errs), json.dumps(errs)
 

--- a/testing/output_tests.py
+++ b/testing/output_tests.py
@@ -69,6 +69,15 @@ def print_failures(test_failures):
     print(TABLE_BAR_LENGTH * "-")
 
 
+def print_errors(test_name, test_value, errs, logger):
+    if errs:
+        logger.info(f"Test {test_name} - Schema test failed for {test_value} with response {errs}")
+        logger.error(test_name)
+        for key in errs.keys():
+            logger.error(f"Expected {key}: {test_value[key]}")
+            logger.error(f"Observed {key}: {errs[key]}\n")
+
+
 def record_results(output_dict, save_results=False):
     print("\n---\n")
     print("Entity Accuracy: {:.2f}".format(output_dict["entity_accuracy"]))


### PR DESCRIPTION
From review by another data scientist at GK, the current test output is very verbose. It will help us identify what goes wrong if we have a succinct summary of what failed and where. This PR is a first blush attempt at generating a file summary for test errors.